### PR TITLE
Package manager support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+node_modules
+src
+rollup.config.js
+test
+.babelrc
+scripts
+styles
+.DS_Store
+.eslintrc.json
+.istanbul.yml
+.travis.yml
+.npmignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: node_js
 node_js:
-  - "6"
-
+  - '6'
 install:
   - npm install
-
 script:
   - npm run test:lint
   - npm test
+  - npm run build
+deploy:
+  provider: npm
+  email: dev@nathanaelcherrier.com
+  api_key:
+    secure: 1wWRD9A9U2WiU9NRDnK+0y2Cek/jKk98DP/ClUh9w4cvmAECX3VnjDOdViLkJSKygU6JnO3WnO9cRinOvnbloKSj9/Pkg9PiivWjdhfpkGh4gNEImQaIVo05R4WJsflOnIPk3wDOO4BYVxp2qtfLu4QRoBzeXbU6rO2mFPUq576hXw9PRopHUMbjPkk9AsyuyU0P8SgfbnuHC0+NcyKTplUvr5/vq/dX8MUWCt/DVXApQUKHicnBLkN+QrO2i84ONFNgo5k+b3T6byapwMMeJbrJhtTkenTSJNn+aKOMwWSnRLuSnxLu2DjnEPZAB1SNwJCE052baeh7dvvqaIXQ40cvDKNo289Yj4tNIwOUtUlzrFK8IcXAfZAKhHgHBhKX06xZPySxeeTMk4+CiNZlCU0mxK1ELyhr8TjBKgP7MS0ovzmkJA83QhnedQOzxrMK2evWWBhq9rTA4GC8GruR33H/q3aSLEP4qRkFUQnS7KHSyEb3ggYpo8azNX2Fv90Yp+0TkFCqxfuh+5NcFV7TcZVKuJATgEbLOxp18Bi+1QRfWvAPxiiMD6u9+jA6ti4VX2ZlxKqRSKGD/XgQfrya1bugvk+ueRzYw3Mrkw04MtP3AD2QX3o60C0V3CuhL4vG7kUhZF3UUd6x1aoT3Zk0kQODcifMUdkWcU8cpKeGL8M=
+  on:
+    branch: master
+    tags: true
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Check the [demo](https://mindsers.github.io/nativetable/) page.
 
 ## Installation
 
+### Package manager installation
+
+Nativetable is available as a client side npm dependency. To install Nativetable with npm :
+
+```bash
+npm install nativetable --save
+```
+
+Nativetable library is ready to be import on your project : `./node_modules/nativetable/dist/nativetable.min.js`
+
+### Manual installation
 You can build your own Nativetable with this project.
 
 Clone the project :
@@ -28,7 +39,7 @@ npm install
 npm run build
 ```
 
-Nativetable library is ready to be import on your project : `src/scripts/build/nativetable.min.js`
+Nativetable library is ready to be import on your project : `./dist/nativetable.min.js`
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativetable",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Create and use dynamics HTML tables with native JS",
   "repository": "https://github.com/Mindsers/nativetable",
   "main": "dist/nativetable.min.js",


### PR DESCRIPTION
Add support for NPM. Nativetable will be available was an NPM package.

CI is up-to-date to continuous deployment on NPM registry.

Close #16 