### PR TITLE
Update license to map LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "filter"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "babel-plugin-istanbul": "^2.0.3",
     "babel-preset-es2015": "^6.16.0",


### PR DESCRIPTION
There are a mistake in `package.json` about license. LICENSE file tell license is MIT but package JSON tell about ISC.