### PR TITLE
Build UMD

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,8 +25,8 @@ export default {
   targets: [
     {
       dest: pkg.main,
-      moduleName: 'Nativetable',
-      format: 'iife'
+      moduleName: 'nativetable',
+      format: 'umd'
     }
   ]
 }

--- a/src/demo/scripts/demo.js
+++ b/src/demo/scripts/demo.js
@@ -1,4 +1,6 @@
-/* global Nativetable */
+/* global nativetable */
+
+const Nativetable = nativetable.Nativetable
 
 'use strict'
 

--- a/src/nativetable/nativetable.js
+++ b/src/nativetable/nativetable.js
@@ -1,4 +1,4 @@
-export default class Nativetable {
+export class Nativetable {
 
   /**
    * Data sources

--- a/test/nativetable.js
+++ b/test/nativetable.js
@@ -2,7 +2,7 @@
 
 import chai from 'chai'
 import spies from 'chai-spies'
-import Nativetable from '../src/nativetable/nativetable'
+import { Nativetable } from '../src/nativetable/nativetable'
 
 describe('Nativetable', () => {
   let nt


### PR DESCRIPTION
Change build mode to support imports with 

```
const Nativetable = require('nativetable').Nativetable
```

 or 

```
import { Nativetable } from 'nativetable'
```

## Compatibility

As Nativetable is a browser module, it needs to be use in module loader for browsers. Nativetable use browser objects and methods like `document` : it can't be used with nodejs